### PR TITLE
fixes 2.12+ deprecation warning on debian 11

### DIFF
--- a/roles/updater/templates/ansible.cfg.j2
+++ b/roles/updater/templates/ansible.cfg.j2
@@ -2,7 +2,7 @@
 {% if ara_plugin_setup.stdout is defined %}
 {{ ara_plugin_setup.stdout }}
 ansible_connection=local
-ansible_python_intepreter=/home/{{ updater_user }}/bin/python
+ansible_python_intepreter=/home/{{ updater_user }}/bin/python3
 ansible_user={{ updater_user }}
 fact_caching_connection={{ ansible_config.fact_caching_connection }}
 fact_caching_timeout={{ ansible_config.fact_caching_timeout }}


### PR DESCRIPTION
Resolves the following deprecation warning

```
Jan 16 11:29:01 octonanny flock[71672]: [DEPRECATION WARNING]: Distribution debian 11 on host localhost should use
Jan 16 11:29:01 octonanny flock[71672]: /usr/bin/python3, but is using /usr/bin/python for backward compatibility with
Jan 16 11:29:01 octonanny flock[71672]: prior Ansible releases. A future Ansible release will default to using the
Jan 16 11:29:01 octonanny flock[71672]: discovered platform python for this host. See https://docs.ansible.com/ansible-
Jan 16 11:29:01 octonanny flock[71672]: core/2.11/reference_appendices/interpreter_discovery.html for more information.
Jan 16 11:29:01 octonanny flock[71672]:  This feature will be removed in version 2.12. Deprecation warnings can be
Jan 16 11:29:01 octonanny flock[71672]: disabled by setting deprecation_warnings=False in ansible.cfg.
```