### PR TITLE
Run updater services as root

### DIFF
--- a/roles/printnanny/templates/reset.service.j2
+++ b/roles/printnanny/templates/reset.service.j2
@@ -10,8 +10,6 @@ After=network-online.target
 Type=oneshot
 RuntimeDirectory={{ updater_app_name }}
 ConfigurationDirectory={{ updater_app_name }}
-User={{ updater_user }}
-
 ExecStart=/usr/bin/flock -F {{ ansible_lockfile }} \
     {{ updater_venv }}/bin/ansible-playbook \
     bitsyai.rpi.printnanny.task.reset

--- a/roles/printnanny/vars/main.yml
+++ b/roles/printnanny/vars/main.yml
@@ -103,7 +103,6 @@ updater_app_name: printnanny
 updater_release_channel: '{{ printnanny.release_channel | default("main") }}'
 updater_tmpfs: '/var/run/{{ updater_app_name }}'
 ansible_lockfile: '/var/run/{{ updater_app_name }}/ansible.lock'
-updater_user: printnanny
 updater_venv: '{{ printnanny_ansible_dir }}/venv'
 ansible_collection_updater: ansible-updater
 ara_enabled: true

--- a/roles/printnanny/vars/main.yml
+++ b/roles/printnanny/vars/main.yml
@@ -103,6 +103,7 @@ updater_app_name: printnanny
 updater_release_channel: '{{ printnanny.release_channel | default("main") }}'
 updater_tmpfs: '/var/run/{{ updater_app_name }}'
 ansible_lockfile: '/var/run/{{ updater_app_name }}/ansible.lock'
+updater_user: ansible
 updater_venv: '{{ printnanny_ansible_dir }}/venv'
 ansible_collection_updater: ansible-updater
 ara_enabled: true

--- a/roles/updater/templates/ansible-updater.service.j2
+++ b/roles/updater/templates/ansible-updater.service.j2
@@ -6,8 +6,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-RuntimeDirectory={{ updater_user }}
-User={{ updater_user }}
+RuntimeDirectory=ansible
 ExecStart={{ updater_venv }}/bin/ansible-galaxy \
     collection install --upgrade {{ updater_collection_url }}
 Restart=on-failure

--- a/roles/updater/templates/ansible-updater.service.j2
+++ b/roles/updater/templates/ansible-updater.service.j2
@@ -6,7 +6,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-RuntimeDirectory=ansible
+RuntimeDirectory={{ updater_user }}
 ExecStart={{ updater_venv }}/bin/ansible-galaxy \
     collection install --upgrade {{ updater_collection_url }}
 Restart=on-failure

--- a/roles/updater/templates/updater.service.j2
+++ b/roles/updater/templates/updater.service.j2
@@ -12,7 +12,6 @@ Wants={{ ansible_collection_updater }}.service network-online.target
 Type=oneshot
 RuntimeDirectory={{ item.app_name }}
 ConfigurationDirectory={{ item.app_name }}
-User={{ item.user }}
 
 {% for playbook in item.playbooks %}
 ExecStart=/usr/bin/flock -F {{ ansible_lockfile }} \

--- a/roles/updater/templates/updater.service.j2
+++ b/roles/updater/templates/updater.service.j2
@@ -2,9 +2,10 @@
 [Unit]
 Description={{ item.name }}
 After={{ ansible_collection_updater }}.service network-online.target
-Wants={{ ansible_collection_updater }}.service network-online.target
 {% if item.timer is defined %}
-Wants={{ item.name }}.timer
+Wants={{ item.name }}.timer {{ ansible_collection_updater }}.service network-online.target
+{% else %}
+Wants={{ ansible_collection_updater }}.service network-online.target
 {% endif %}
 
 [Service]


### PR DESCRIPTION
There are some counter-intuitive designs to rootless Ansible, esp for password lookup module which does not use `become` or `become_user` directives. I'd have to think a little harder about the right playbook-level setup to get rootless to work. Just run updaters as root for now.
```
TASK [bitsyai.rpi.printnanny : Create set fact printnanny_www_secret_key] ********************************************************************************************************************************************
task path: /home/printnanny/.ansible/collections/ansible_collections/bitsyai/rpi/roles/printnanny/tasks/secrets.yml:45
fatal: [localhost]: FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'password'. Error was a <class 'PermissionError'>, original message: [Errno 13] Permission denied: b'/opt/printnanny/www/bb0e415c14beb3700fbd24f273bbc59a081fa09b.ansible_lockfile'"
}
```