### PR TITLE
fix janus add-token cmd

### DIFF
--- a/roles/printnanny/vars/main.yml
+++ b/roles/printnanny/vars/main.yml
@@ -81,7 +81,7 @@ janus_exec_start_post:
     printnanny
     janus-admin
     --host {{ janus_admin_url }}
-    addtoken
+    add-token
     --token ${JANUS_TOKEN}
     --adminsecret ${JANUS_ADMIN_SECRET}
 


### PR DESCRIPTION
Fixes the following error after upgrading Clap 2 -> 3

```
<30>1 2022-01-17T09:29:18.420344-08:00 slim-nanny flock 2085 - -  TASK [bitsyai.rpi.printnanny : Configure printnanny user/groups] ***************
<30>1 2022-01-17T09:29:21.339216-08:00 slim-nanny printnanny 2957 - -  error: "addtoken" isn't a valid value for '<endpoint>'
<30>1 2022-01-17T09:29:21.339763-08:00 slim-nanny printnanny 2957 - -  #011[possible values: add-token, get-status, info, list-tokens, ping, remove-token, test-stun]
<30>1 2022-01-17T09:29:21.339852-08:00 slim-nanny printnanny 2957 - -  #011Did you mean "add-token"?
<30>1 2022-01-17T09:29:21.339937-08:00 slim-nanny printnanny 2957 - -  USAGE:
<30>1 2022-01-17T09:29:21.340024-08:00 slim-nanny printnanny 2957 - -      printnanny --api-config <api_config> --api-token <api_token> janus-admin --host <host> --token <token> --adminsecret <admin_secret> --plugins <plugins> <endpoint>
<30>1 2022-01-17T09:29:21.340106-08:00 slim-nanny printnanny 2957 - -  For more information try --help
<29>1 2022-01-17T09:29:21.345257-08:00 slim-nanny systemd 1 - -  janus.service: Control process exited, code=exited, status=2/INVALIDARGUMENT
```