### PR TITLE
fix ERROR! 'cam_rtp_service' is undefined in handlers definitions

### DIFF
--- a/roles/printnanny/handlers/main.yml
+++ b/roles/printnanny/handlers/main.yml
@@ -60,14 +60,6 @@
     state: restarted
     no_block: true
 
-- name: restart {{ cam_rtp_service }}
-  become: true
-  ansible.builtin.systemd:
-    daemon_reload: true
-    name: '{{ cam_rtp_service }}'
-    state: restarted
-    no_block: true
-
 - name: restart printnanny-metadata
   become: true
   ansible.builtin.systemd:


### PR DESCRIPTION
Fixes the following error when handlers are triggered

```
Jan 31 16:12:20 octonanny-dev ansible-playbook[12206]: ERROR! 'cam_rtp_service' is undefined
```