### PR TITLE
Use a longer restart delay to give printnanny-gst time to recover

### DIFF
--- a/roles/printnanny/templates/camera/printnanny-gst.service.j2
+++ b/roles/printnanny/templates/camera/printnanny-gst.service.j2
@@ -9,6 +9,6 @@ Type=simple
 User={{ printnanny_user }}
 ExecStart=/usr/local/bin/printnanny-monitor
 Restart=on-failure
-
+RestartSec=10
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd quickly hits retry frequency limit if resources fail to be
freed:
```
Feb 01 09:25:54 octonanny-dev systemd[1]: printnanny-gst.service: Start request repeated too quickly.
Feb 01 09:25:54 octonanny-dev systemd[1]: printnanny-gst.service: Failed with result 'exit-code'.
Feb 01 09:25:54 octonanny-dev systemd[1]: Failed to start Gstreamer RTP Camera Sink.
````