### PR TITLE
Fix deprecation notice on handlers imports

### DIFF
--- a/playbooks/printnanny/metadata/env.yml
+++ b/playbooks/printnanny/metadata/env.yml
@@ -15,7 +15,7 @@
         tasks_from: env/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../roles/printnanny/handlers/main.yml
-      static: false
-    - include: ../../roles/janus/handlers/main.yml
-      static: false
+    - include: ../../../roles/printnanny/handlers/main.yml
+      static: true
+    - include: ../../../roles/janus/handlers/main.yml
+      static: true

--- a/playbooks/printnanny/metadata/env.yml
+++ b/playbooks/printnanny/metadata/env.yml
@@ -15,5 +15,7 @@
         tasks_from: env/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../../roles/printnanny/handlers/main.yml
-    - include: ../../../roles/janus/handlers/main.yml
+    - include: ../../roles/printnanny/handlers/main.yml
+      static: false
+    - include: ../../roles/janus/handlers/main.yml
+      static: false

--- a/playbooks/printnanny/metadata/env.yml
+++ b/playbooks/printnanny/metadata/env.yml
@@ -15,5 +15,5 @@
         tasks_from: env/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../roles/printnanny/handlers/main.yml
-    - include: ../../roles/janus/handlers/main.yml
+    - include: ../../../roles/printnanny/handlers/main.yml
+    - include: ../../../roles/janus/handlers/main.yml

--- a/playbooks/printnanny/metadata/janus.yml
+++ b/playbooks/printnanny/metadata/janus.yml
@@ -15,5 +15,5 @@
         tasks_from: janus/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../roles/printnanny/handlers/main.yml
-    - include: ../../roles/janus/handlers/main.yml
+    - include: ../../../roles/printnanny/handlers/main.yml
+    - include: ../../../roles/janus/handlers/main.yml

--- a/playbooks/printnanny/metadata/janus.yml
+++ b/playbooks/printnanny/metadata/janus.yml
@@ -15,5 +15,7 @@
         tasks_from: janus/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../../roles/printnanny/handlers/main.yml
-    - include: ../../../roles/janus/handlers/main.yml
+    - include: ../../roles/printnanny/handlers/main.yml
+      static: false
+    - include: ../../roles/janus/handlers/main.yml
+      static: false

--- a/playbooks/printnanny/metadata/janus.yml
+++ b/playbooks/printnanny/metadata/janus.yml
@@ -15,7 +15,7 @@
         tasks_from: janus/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../roles/printnanny/handlers/main.yml
-      static: false
-    - include: ../../roles/janus/handlers/main.yml
-      static: false
+    - include: ../../../roles/printnanny/handlers/main.yml
+      static: true
+    - include: ../../../roles/janus/handlers/main.yml
+      static: true

--- a/playbooks/printnanny/metadata/mqtt.yml
+++ b/playbooks/printnanny/metadata/mqtt.yml
@@ -15,7 +15,7 @@
         tasks_from: mqtt/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../roles/printnanny/handlers/main.yml
-      static: false
-    - include: ../../roles/janus/handlers/main.yml
-      static: false
+    - include: ../../../roles/printnanny/handlers/main.yml
+      static: true
+    - include: ../../../roles/janus/handlers/main.yml
+      static: true

--- a/playbooks/printnanny/metadata/mqtt.yml
+++ b/playbooks/printnanny/metadata/mqtt.yml
@@ -15,5 +15,7 @@
         tasks_from: mqtt/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../../roles/printnanny/handlers/main.yml
-    - include: ../../../roles/janus/handlers/main.yml
+    - include: ../../roles/printnanny/handlers/main.yml
+      static: false
+    - include: ../../roles/janus/handlers/main.yml
+      static: false

--- a/playbooks/printnanny/metadata/mqtt.yml
+++ b/playbooks/printnanny/metadata/mqtt.yml
@@ -15,5 +15,5 @@
         tasks_from: mqtt/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../roles/printnanny/handlers/main.yml
-    - include: ../../roles/janus/handlers/main.yml
+    - include: ../../../roles/printnanny/handlers/main.yml
+    - include: ../../../roles/janus/handlers/main.yml

--- a/playbooks/printnanny/metadata/www.yml
+++ b/playbooks/printnanny/metadata/www.yml
@@ -15,5 +15,5 @@
         tasks_from: wwww/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../roles/printnanny/handlers/main.yml
-    - include: ../../roles/janus/handlers/main.yml
+    - include: ../../../roles/printnanny/handlers/main.yml
+    - include: ../../../roles/janus/handlers/main.yml

--- a/playbooks/printnanny/metadata/www.yml
+++ b/playbooks/printnanny/metadata/www.yml
@@ -15,7 +15,7 @@
         tasks_from: wwww/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../roles/printnanny/handlers/main.yml
-      static: false
-    - include: ../../roles/janus/handlers/main.yml
-      static: false
+    - include: ../../../roles/printnanny/handlers/main.yml
+      static: true
+    - include: ../../../roles/janus/handlers/main.yml
+      static: true

--- a/playbooks/printnanny/metadata/www.yml
+++ b/playbooks/printnanny/metadata/www.yml
@@ -15,5 +15,7 @@
         tasks_from: wwww/main.yml
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
-    - include: ../../../roles/printnanny/handlers/main.yml
-    - include: ../../../roles/janus/handlers/main.yml
+    - include: ../../roles/printnanny/handlers/main.yml
+      static: false
+    - include: ../../roles/janus/handlers/main.yml
+      static: false


### PR DESCRIPTION
```
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: [DEPRECATION WARNING]: Included file '/root/.ansible/collections/ansible_collec
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: tions/bitsyai/rpi/playbooks/roles/printnanny/handlers/main.yml' not found,
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: however since this include is not explicitly marked as 'static: yes', we will
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: try and include it dynamically later. In the future, this will be an error
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: unless 'static: no' is used on the include task. If you do not want missing
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: includes to be considered dynamic, use 'static: yes' on the include or set the
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: global ansible.cfg options to make all includes static for tasks and/or
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: handlers. This feature will be removed from ansible-core in version 2.12.
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: Deprecation warnings can be disabled by setting deprecation_warnings=False in
Feb  1 09:59:42 octonanny-dev ansible-playbook[37371]: ansible.cfg.
```