### PR TITLE
Fix deprecation warning: static imports

### DIFF
--- a/playbooks/printnanny/metadata/env.yml
+++ b/playbooks/printnanny/metadata/env.yml
@@ -16,6 +16,4 @@
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
     - include: ../../../roles/printnanny/handlers/main.yml
-      static: true
     - include: ../../../roles/janus/handlers/main.yml
-      static: true

--- a/playbooks/printnanny/metadata/janus.yml
+++ b/playbooks/printnanny/metadata/janus.yml
@@ -16,6 +16,4 @@
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
     - include: ../../../roles/printnanny/handlers/main.yml
-      static: true
     - include: ../../../roles/janus/handlers/main.yml
-      static: true

--- a/playbooks/printnanny/metadata/mqtt.yml
+++ b/playbooks/printnanny/metadata/mqtt.yml
@@ -16,6 +16,4 @@
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
     - include: ../../../roles/printnanny/handlers/main.yml
-      static: true
     - include: ../../../roles/janus/handlers/main.yml
-      static: true

--- a/playbooks/printnanny/metadata/www.yml
+++ b/playbooks/printnanny/metadata/www.yml
@@ -16,6 +16,4 @@
         vars_from: '{{ printnanny_profile }}.yml'
   handlers:
     - include: ../../../roles/printnanny/handlers/main.yml
-      static: true
     - include: ../../../roles/janus/handlers/main.yml
-      static: true


### PR DESCRIPTION
Feb  1 10:10:29 octonanny-dev ansible-playbook[47545]: [DEPRECATION WARNING]: The use of 'static' has been deprecated. Use
Feb  1 10:10:29 octonanny-dev ansible-playbook[47545]: 'import_tasks' for static inclusion, or 'include_tasks' for dynamic inclusion.