### PR TITLE
Enable metadata.target for synchronization of all metadata units

### DIFF
--- a/roles/metadata/tasks/main.yml
+++ b/roles/metadata/tasks/main.yml
@@ -36,6 +36,14 @@
     - metadata
 - name: Enable metadata services
   ansible.builtin.systemd:
+    name: 'printnanny-metadata.target'
+    enabled: true
+    no_block: true
+  with_items: '{{ metadata_apps }}'
+  tags:
+    - metadata
+- name: Enable metadata services
+  ansible.builtin.systemd:
     name: 'printnanny-metadata@{{ item }}.service'
     enabled: true
     no_block: true

--- a/roles/metadata/tasks/main.yml
+++ b/roles/metadata/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Render printnanny-metadata.target
   ansible.builtin.template:
     src: printnanny-metadata.target.j2
-    dest: /etc/systemd/system/printnanny-metadata@.target
+    dest: /etc/systemd/system/printnanny-metadata.target
     mode: 0664
     force: true
   tags:


### PR DESCRIPTION
Fixes the following issue when restarting all metadata svcs:

```
pi@octonanny-dev:~ $ sudo systemctl restart printnanny-metadata.target
Failed to restart printnanny-metadata.target: Unit printnanny-metadata.target not found.
```
```
pi@octonanny-dev:~ $ sudo systemctl enable printnanny-metadata.target
Failed to enable unit: Unit file printnanny-metadata.target does not exist.
```