### PR TITLE
Debug janus/libcamera installed version vars

### DIFF
--- a/roles/janus/tasks/main.yml
+++ b/roles/janus/tasks/main.yml
@@ -13,9 +13,17 @@
     path: /opt/janus/bin/janus
   register: janus_bin
 
-- name: ansible_local
+- name: Debug ansible_local
   ansible.builtin.debug:
     var: ansible_local
+
+- name: Debug janus_version
+  ansible.builtin.debug:
+    var: janus_version
+
+- name: Debug janus_intalled_version
+  ansible.builtin.debug:
+    var: janus_installed_version
 
 # all tasks requiring access to secrets must appear after this task
 - include_tasks: build/main.yml

--- a/roles/printnanny/tasks/camera.yml
+++ b/roles/printnanny/tasks/camera.yml
@@ -63,6 +63,14 @@
     enabled: true
     no_block: true
 
+- name: Debug libcamera_version
+  ansible.builtin.debug:
+    var: libcamera_version
+
+- name: Debug libcamera_installed_version
+  ansible.builtin.debug:
+    var: libcamera_installed_version
+
 - name: Import libcamera tasks
   include_tasks: libcamera.yml
   when: libcamera_installed_version != libcamera_version


### PR DESCRIPTION
The following conditions appear to always be true, resulting in libcamera/janus being built from source on every run of printnanny-update. Adds debug tasks to figure out what's going on here.

```
libcamera_installed_version != libcamera_version
janus_version != janus_installed_version
```