### PR TITLE
Configure rocket app to listen on loopback instead of ip4 bind + serve OctoPrint on /octoprint/

### DIFF
--- a/roles/octoprint/templates/nginx.conf.j2
+++ b/roles/octoprint/templates/nginx.conf.j2
@@ -1,4 +1,3 @@
-
 server {
     listen 443;
     server_name octoprint.$hostname;
@@ -16,5 +15,19 @@ server {
     proxy_pass          http://localhost:{{ octoprint_port }};
     proxy_read_timeout  90;
     proxy_redirect      http://localhost:{{ octoprint_port }} https://octoprint.$hostname;
+    }
+}
+server {
+    listen 80;
+    server_name octoprint.$hostname;
+    location / {
+
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_pass          http://localhost:{{ octoprint_port }};
+    proxy_read_timeout  90;
+    proxy_redirect      http://localhost:{{ octoprint_port }} http://octoprint.$hostname;
     }
 }

--- a/roles/octoprint/templates/nginx.conf.j2
+++ b/roles/octoprint/templates/nginx.conf.j2
@@ -6,28 +6,34 @@ server {
     ssl_certificate_key {{ octoprint_ssl_key }};
     ssl_protocols       {{ octoprint_ssl_protocols }};
     ssl_ciphers         {{ octoprint_ssl_ciphers }}
-    location / {
+    location /octoprint/ {
 
     proxy_set_header        Host $host;
+    proxy_set_header Upgrade $http_upgrade;
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Proto $scheme;
-    proxy_pass          http://localhost:{{ octoprint_port }};
+    proxy_set_header        X-Scheme $scheme;
+    proxy_set_header        X-Script-Name /octoprint;
+    proxy_http_version 1.1;
+    proxy_pass http://localhost:{{ octoprint_port }}/; # make sure to add trailing slash here!
     proxy_read_timeout  90;
     proxy_redirect      http://localhost:{{ octoprint_port }} https://octoprint.$hostname;
     }
 }
+
 server {
     listen 80;
-    server_name octoprint.$hostname;
-    location / {
-
-    proxy_set_header        Host $host;
-    proxy_set_header        X-Real-IP $remote_addr;
-    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Proto $scheme;
-    proxy_pass          http://localhost:{{ octoprint_port }};
-    proxy_read_timeout  90;
-    proxy_redirect      http://localhost:{{ octoprint_port }} http://octoprint.$hostname;
+    server_name $hostname;
+    location /octoprint/ {
+        proxy_pass http://localhost:{{ octoprint_port }}/; # make sure to add trailing slash here!
+        proxy_set_header Host $http_host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Script-Name /octoprint;
+        proxy_http_version 1.1;
     }
 }

--- a/roles/printnanny/defaults/main.yml
+++ b/roles/printnanny/defaults/main.yml
@@ -26,7 +26,7 @@ printnanny_ansible_dir: "{{ printnanny_install_dir }}/ansible"
 printnanny_www_dir: '{{ printnanny_profile_dir }}/www'
 printnanny_www_secret_file: '{{ printnanny_www_dir }}/key'
 printnanny_www_templates_dir: '{{ printnanny_www_dir }}/templates'
-printnanny_www_address: "0.0.0.0"
+printnanny_www_address: "127.0.0.1"
 printnanny_www_port: 9001
 printnanny_www_log_level: "normal"
 

--- a/roles/printnanny/templates/nginx.conf.j2
+++ b/roles/printnanny/templates/nginx.conf.j2
@@ -17,3 +17,17 @@ server {
     proxy_redirect      http://localhost:{{ printnanny_www_port }} https://$hostname;
     }
 }
+server {
+    listen 80;
+    server_name $hostname;    
+    location / {
+
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_pass          http://localhost:9001
+    proxy_read_timeout  90;
+    proxy_redirect      http://localhost:9001 https://$hostname;
+    }
+}


### PR DESCRIPTION
nginx is now proxying traffic to internal loopback