### PR TITLE
Run updater once; rm restart on failure directive

### DIFF
--- a/roles/metadata/templates/update/printnanny-update.service.j2
+++ b/roles/metadata/templates/update/printnanny-update.service.j2
@@ -17,7 +17,6 @@ ExecStart=/usr/bin/flock -F {{ ansible_lockfile }} \
 {% endfor %}
 ExecStartPost=-/usr/bin/flock -F {{ ansible_lockfile }} \
     /usr/bin/rm {{ ansible_lockfile }}
-Restart=on-failure
 
 {% if printnanny_update_log is defined %}
 StandardOutput=file:{{ printnanny_update_log }}.stdout


### PR DESCRIPTION
The updater entrying a looping retry state on failure is confusing to end-users. Attempt to update once and report the result.