### PR TITLE
move systemd package install into printnanny role

### DIFF
--- a/roles/janus/tasks/build/main.yml
+++ b/roles/janus/tasks/build/main.yml
@@ -18,6 +18,7 @@
       - libopus-dev
       - libsofia-sip-ua-dev
       - libssl-dev
+      - libsystemd-dev
       - libtool
       - ninja-build
       - pkg-config

--- a/roles/janus/tasks/build/main.yml
+++ b/roles/janus/tasks/build/main.yml
@@ -18,12 +18,9 @@
       - libopus-dev
       - libsofia-sip-ua-dev
       - libssl-dev
-      - libsystemd-dev
       - libtool
       - ninja-build
       - pkg-config
-      - systemd
-      - systemd-cron
       - wget
     state: present
   tags:

--- a/roles/nebula/tasks/main.yml
+++ b/roles/nebula/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Install systemd
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true
     name:
       - libsystemd-dev

--- a/roles/printnanny/tasks/apt.yml
+++ b/roles/printnanny/tasks/apt.yml
@@ -6,13 +6,13 @@
     state: present
     codename: focal
 
-- name: Remove cron
+- name: Install systemd-cron (allow uninstall cron)
   ansible.builtin.apt:
-    autoclean: true
-    purge: true
+    install_recommends: true
     name:
-      - cron
-    state: absent
+      - systemd
+      - systemd-cron
+    state: present
 
 - name: Install apt dependencies
   ansible.builtin.apt:
@@ -35,10 +35,6 @@
       - rustc
       - sudo
       - vim
-      # systemd
-      - systemd-cron
-      - systemd
-      - libsystemd-dev
       # required by ansible.builtin.package_facts
       - python3-apt
       # gstreamer

--- a/roles/printnanny/tasks/apt.yml
+++ b/roles/printnanny/tasks/apt.yml
@@ -6,10 +6,17 @@
     state: present
     codename: focal
 
+- name: Remove cron-daemon
+  ansible.builtin.apt:
+    autoclean: true
+    purge: true
+    name:
+      - cron-daemon
+    state: absent
+
 - name: Install apt dependencies
   ansible.builtin.apt:
     update_cache: true
-    autoclean: true
     name:
       # common
       - ca-certificates

--- a/roles/printnanny/tasks/apt.yml
+++ b/roles/printnanny/tasks/apt.yml
@@ -6,12 +6,12 @@
     state: present
     codename: focal
 
-- name: Remove cron-daemon
+- name: Remove cron
   ansible.builtin.apt:
     autoclean: true
     purge: true
     name:
-      - cron-daemon
+      - cron
     state: absent
 
 - name: Install apt dependencies

--- a/roles/printnanny/tasks/apt.yml
+++ b/roles/printnanny/tasks/apt.yml
@@ -6,19 +6,13 @@
     state: present
     codename: focal
 
-- name: Ensure ca-certificates package up-to-date
-  become: true
-  ansible.builtin.apt:
-    update_cache: true
-    state: latest
-    name:
-      - ca-certificates
-
 - name: Install apt dependencies
   ansible.builtin.apt:
     update_cache: true
+    autoclean: true
     name:
       # common
+      - ca-certificates
       - cron
       - git
       - jq
@@ -34,6 +28,10 @@
       - rustc
       - sudo
       - vim
+      # systemd
+      - systemd-cron
+      - systemd
+      - libsystemd-dev
       # required by ansible.builtin.package_facts
       - python3-apt
       # gstreamer


### PR DESCRIPTION
Fixes `systemd-cron` package not being installed correctly during image build

```
systemd-cron/stable,now 1.5.16-1 arm64 [residual-config]
  systemd units to provide cron daemon & anacron functionality
```