### PR TITLE
Acquire flock on ansible_lockfile in ansible-collection.service

### DIFF
--- a/roles/metadata/templates/update/ansible-collection.service.j2
+++ b/roles/metadata/templates/update/ansible-collection.service.j2
@@ -7,8 +7,11 @@ Wants=network.service network-online.target
 [Service]
 SyslogIdentifier=ansible-collection
 Type=oneshot
-ExecStart={{ updater_venv }}/bin/ansible-galaxy \
+ExecStart=/usr/bin/flock -F {{ ansible_lockfile }} \
+    {{ updater_venv }}/bin/ansible-galaxy \
     collection install --upgrade {{ updater_collection_url }}
+ExecStartPost=-/usr/bin/flock -F {{ ansible_lockfile }} \
+    /usr/bin/rm {{ ansible_lockfile }}
 Restart=on-failure
 
 [Install]

--- a/roles/printnanny/templates/systemd/printnanny.target.j2
+++ b/roles/printnanny/templates/systemd/printnanny.target.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Print Nanny Services
-After=network.target network-online.target ansible-collection.service
-Wants=network.target network-online.target ansible-collection.service
+After=network.target network-online.target
+Wants=network.target network-online.target
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Failures in printnanny.target cause the collection updater to cycle, which results in any failures in active ansible plays (collection is deleted)