### PR TITLE
Resolves missing runtime dir errors in ansible-collection.service

### DIFF
--- a/roles/metadata/templates/update/ansible-collection.service.j2
+++ b/roles/metadata/templates/update/ansible-collection.service.j2
@@ -7,6 +7,8 @@ Wants=network.service network-online.target
 [Service]
 SyslogIdentifier=ansible-collection
 Type=oneshot
+RuntimeDirectory={{ updater_app_name }}
+ConfigurationDirectory={{ updater_app_name }}
 ExecStart=/usr/bin/flock -F {{ ansible_lockfile }} \
     {{ updater_venv }}/bin/ansible-galaxy \
     collection install --upgrade {{ updater_collection_url }}


### PR DESCRIPTION
Feb 12 15:39:03 octonanny-dev ansible-collection[39185]: flock: cannot open lock file /var/run/printnanny/ansible.lock: No such file or directory